### PR TITLE
Make protocolParams to be standard

### DIFF
--- a/src/transaction/Transaction.ts
+++ b/src/transaction/Transaction.ts
@@ -277,8 +277,8 @@ export class Transaction {
     }
 
     const memPrice = new BigNumber(totalMem).times(this._protocolParams.priceMem);
-    const stepsPrice = new BigNumber(totalSteps).times(this._protocolParams.priceSteps);
-    return memPrice.plus(stepsPrice).integerValue(BigNumber.ROUND_CEIL);
+    const stepPrice = new BigNumber(totalSteps).times(this._protocolParams.priceStep);
+    return memPrice.plus(stepPrice).integerValue(BigNumber.ROUND_CEIL);
   }
 
   calculateFee(extraOutputs?: Array<Output>): BigNumber {
@@ -541,7 +541,7 @@ export class Transaction {
       this.certificates,
       (result, cert) => {
         if (cert.certType === CertificateType.STAKE_REGISTRATION) {
-          return result.plus(this._protocolParams.stakeKeyDeposit);
+          return result.plus(this._protocolParams.keyDeposit);
         }
         return result;
       },
@@ -554,7 +554,7 @@ export class Transaction {
       this.certificates,
       (result, cert) => {
         if (cert.certType === CertificateType.STAKE_DE_REGISTRATION) {
-          return result.plus(this._protocolParams.stakeKeyDeposit);
+          return result.plus(this._protocolParams.keyDeposit);
         }
         return result;
       },

--- a/src/transaction/transactionBuilder.ts
+++ b/src/transaction/transactionBuilder.ts
@@ -45,10 +45,7 @@ export function transactionBuilder({
     }
   };
 
-  const minUtxo = calculateMinUtxoAmount(
-    [],
-    new BigNumber(transaction.protocolParams.lovelacePerUtxoWord)
-  );
+  const minUtxo = calculateMinUtxoAmount([], transaction.protocolParams.lovelacePerUtxoWord);
 
   const utxoInputs = _.cloneDeep(inputs);
 
@@ -120,7 +117,7 @@ export function transactionBuilder({
       for (const [index, tokens] of tokensTokens.entries()) {
         const minUtxo = calculateMinUtxoAmount(
           tokens,
-          new BigNumber(transaction.protocolParams.lovelacePerUtxoWord)
+          transaction.protocolParams.lovelacePerUtxoWord
         );
         let outputAmount = minUtxo;
         if (index === tokensTokens.length - 1) {
@@ -216,7 +213,7 @@ export function transactionBuilder({
       tokensTokens.forEach((tokens, index) => {
         const minUtxo = calculateMinUtxoAmount(
           tokens,
-          new BigNumber(transaction.protocolParams.lovelacePerUtxoWord)
+          transaction.protocolParams.lovelacePerUtxoWord
         );
         let outputAmount = minUtxo;
         if (index === tokensTokens.length - 1) {
@@ -254,7 +251,7 @@ export function transactionBuilder({
     tokensTokens.forEach((tokens, index) => {
       const minUtxo = calculateMinUtxoAmount(
         tokens,
-        new BigNumber(transaction.protocolParams.lovelacePerUtxoWord)
+        transaction.protocolParams.lovelacePerUtxoWord
       );
       let outputAmount = minUtxo;
       if (index === tokensTokens.length - 1) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -399,12 +399,13 @@ export type LanguageView = {
 };
 
 export type ProtocolParams = {
-  minFeeA: BigNumber;
-  minFeeB: BigNumber;
-  stakeKeyDeposit: BigNumber;
-  lovelacePerUtxoWord: BigNumber;
-  collateralPercent: BigNumber;
-  priceSteps: BigNumber;
-  priceMem: BigNumber;
+  minFeeA: number;
+  minFeeB: number;
+  keyDeposit: number;
+  // Deprecated, use coinsPerUtxoByte
+  lovelacePerUtxoWord: number;
+  collateralPercent: number;
+  priceStep: number;
+  priceMem: number;
   languageView: LanguageView;
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -25,7 +25,7 @@ import { TokenBundle } from "../internal-types";
 
 export const calculateMinUtxoAmount = (
   tokens: Array<Token>,
-  lovelacePerUtxoWord: BigNumber,
+  lovelacePerUtxoWord: number,
   hasPlutusDataHash?: boolean
 ): BigNumber => {
   const uniqueTokens = getUniqueTokens(tokens);
@@ -66,12 +66,12 @@ export const calculateMinUtxoAmount = (
   const size =
     6 + roundupBytesToWords(uniqueTokens.length * 12 + assetNameSize + policyCount * policyIdSize);
 
-  const minUtxo = lovelacePerUtxoWord.toNumber() * adaOnlyUtxoSize;
+  const minUtxo = lovelacePerUtxoWord * adaOnlyUtxoSize;
 
   if (uniqueTokens.length === 0) {
     return new BigNumber(minUtxo);
   }
-  const minUtxoWithTokens = lovelacePerUtxoWord.toNumber() * (utxoEntrySizeWithoutVal + size);
+  const minUtxoWithTokens = lovelacePerUtxoWord * (utxoEntrySizeWithoutVal + size);
   return BigNumber.max(minUtxo, minUtxoWithTokens);
 };
 

--- a/tests/stub.ts
+++ b/tests/stub.ts
@@ -4,13 +4,13 @@ import { BaseAddress } from "../src/address";
 import { HashCredential, HashType, Input, NetworkId } from "../src/types";
 
 export const pParams = {
-  minFeeA: new BigNumber(44),
-  minFeeB: new BigNumber(155381),
-  stakeKeyDeposit: new BigNumber(2000000),
-  lovelacePerUtxoWord: new BigNumber(34482),
-  collateralPercent: new BigNumber(150),
-  priceSteps: new BigNumber(0.0577),
-  priceMem: new BigNumber(0.0000721),
+  minFeeA: 44,
+  minFeeB: 155381,
+  keyDeposit: 2000000,
+  lovelacePerUtxoWord: 34482,
+  collateralPercent: 150,
+  priceStep: 0.0000721,
+  priceMem: 0.0577,
   languageView: {
     PlutusScriptV1: {
       "sha2_256-memory-arguments": 4,


### PR DESCRIPTION
This PR makes `protocolParams` look like parameters from Cardano GraphQL response.

1. Make number values to be js Number type.
2. Rename `stakeKeyDeposit` to `keyDeposit`
3. Rename `priceSteps` to `priceStep` (ending `s`)
4. Swap values of `priceStep` and `priceMem` according to latest API response.

Docs:
* https://input-output-hk.github.io/cardano-graphql/
* https://graphql-api.testnet.dandelion.link/