### PR TITLE
Rename getAddressFromBech32 to getAddressFromString

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -180,9 +180,9 @@ export const decodeBech32 = (bech32Address: string): { prefix: string; value: st
   };
 };
 
-export const getAddressFromBech32 = (bech32Address: string): CardanoAddress => {
+export const getAddressFromString = (address: string): CardanoAddress => {
   try {
-    const byronAddress = Buffer.from(bs58.decode(bech32Address));
+    const byronAddress = Buffer.from(bs58.decode(address));
     try {
       cbors.Decoder.decode(byronAddress);
     } catch (e) {
@@ -191,7 +191,7 @@ export const getAddressFromBech32 = (bech32Address: string): CardanoAddress => {
     return new ByronAddress(byronAddress);
   } catch (error) {
     try {
-      const decodeAddr = decodeBech32(bech32Address);
+      const decodeAddr = decodeBech32(address);
       if (
         decodeAddr.prefix === "addr" ||
         decodeAddr.prefix === "addr_test" ||

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -46,7 +46,7 @@ describe("Typhonjs", (): void => {
     });
 
     it("get address from bech32", () => {
-      const address = utils.getAddressFromBech32(
+      const address = utils.getAddressFromString(
         "addr1q9dmtr22dz54qn8pgx4yhle64nhwpqjyxsueaetdcxxa7k5jhh20yrgtl00c5mqnpjm5p8aud9cqldgwf3rq8dxvgy4snhadga"
       );
       expect(address instanceof CardanoAddress.BaseAddress).to.eq(true);
@@ -91,7 +91,7 @@ describe("Typhonjs", (): void => {
   describe("address", () => {
     describe(`Enterprise Address`, () => {
       const adr = "addr1v8s64t9zghl44sewflpszrfx4jqc7mppd8hgp2ctakuqpaq3k5f9m";
-      const address = utils.getAddressFromBech32(adr) as CardanoAddress.EnterpriseAddress;
+      const address = utils.getAddressFromString(adr) as CardanoAddress.EnterpriseAddress;
       const hex = address.getHex();
       const paymentHash = address.paymentCredential.hash;
       const hashType = address.paymentCredential.type;
@@ -128,7 +128,7 @@ describe("Typhonjs", (): void => {
     describe(`Base Address`, () => {
       const adr =
         "addr1q9dmtr22dz54qn8pgx4yhle64nhwpqjyxsueaetdcxxa7k5jhh20yrgtl00c5mqnpjm5p8aud9cqldgwf3rq8dxvgy4snhadga";
-      const address = utils.getAddressFromBech32(adr) as CardanoAddress.BaseAddress;
+      const address = utils.getAddressFromString(adr) as CardanoAddress.BaseAddress;
       const hex = address.getHex();
       const paymentHash = address.paymentCredential.hash;
       const hashType = address.paymentCredential.type;
@@ -182,7 +182,7 @@ describe("Typhonjs", (): void => {
     });
     describe(`Reward Address`, () => {
       const adr = "stake1uxftm48jp59lhhu2dsfsed6qn77xjuq0k58yc3srknxyz2ct9x80q";
-      const address = utils.getAddressFromBech32(adr) as CardanoAddress.RewardAddress;
+      const address = utils.getAddressFromString(adr) as CardanoAddress.RewardAddress;
       const hex = address.getHex();
       const stakeHash = address.stakeCredential.hash;
       const stakeHashType = address.stakeCredential.type;

--- a/tests/stub.ts
+++ b/tests/stub.ts
@@ -259,7 +259,7 @@ const address1 = new BaseAddress(NetworkId.MAINNET, paymentCred0, stakeCredentia
 const address2 = new BaseAddress(NetworkId.MAINNET, paymentCred1, stakeCredential);
 
 export const changeAddress = new BaseAddress(NetworkId.MAINNET, paymentCredChange, stakeCredential);
-export const receiverAddress = utils.getAddressFromBech32(
+export const receiverAddress = utils.getAddressFromString(
   "addr1qycq3tsm0efv9gtwdpet0r5rx6xjgezkat84jyypufnzd2uaqtd5xya2y49fx5tr68ezuew4hd04nedg4udzx8gnxlns9j9kd5"
 );
 


### PR DESCRIPTION
This PR renames `utils.getAddressFromBech32` to `utils.getAddressFromString` to be more consistent in method names.

`getAddressFromString` parses both bech32 and bs58 addresses.