### PR TITLE
fix: don't use localeCompare to compare string

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -78,6 +78,8 @@ export const compareCanonically = (str1: string, str2: string): number => {
   if (str1.length !== str2.length) {
     return str1.length - str2.length
   }
+  str1 = str1.toLowerCase()
+  str2 = str2.toLowerCase()
   if (str1 < str2) {
     return -1
   } else if (str1 > str2) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -74,8 +74,18 @@ export const sanitizeMetadata = (metadata: unknown): unknown => {
   return metadata;
 };
 
-export const compareCanonically = (str1: string, str2: string): number =>
-  str1.length - str2.length || str1.localeCompare(str2);
+export const compareCanonically = (str1: string, str2: string): number => {
+  if (str1.length !== str2.length) {
+    return str1.length - str2.length
+  }
+  if (str1 < str2) {
+    return -1
+  } else if (str1 > str2) {
+    return 1
+  } else {
+    return 0
+  }
+}
 
 export const sortTokens = (tokens: Array<Token>): Array<Token> => {
   const sortedTokens = _(tokens)


### PR DESCRIPTION
`localCompare` behaves differently based on user's locale
we got a few bugs recently because we use `localeCompare` to encode cost models, so some users get different script data hash